### PR TITLE
Feature: troll shield anti ban system

### DIFF
--- a/troll_shield.go
+++ b/troll_shield.go
@@ -196,24 +196,26 @@ func setupBot(envVar string) (*telegram.BotAPI, error) {
 	return bot, nil
 }
 
-func setupBots() (*telegram.BotAPI, *telegram.BotAPI, error) {
-	var bot, botHidden *telegram.BotAPI
-	var err error
-
-	log.Println("Setup the main bot")
-	bot, err = setupBot("TELEGRAM_BOT_TOKEN")
-	if err != nil {
-		return nil, nil, err
-	}
-
+func setupHiddenBot(bot *telegram.BotAPI) *telegram.BotAPI {
 	log.Println("Setup the hidden bot")
-	botHidden, err = setupBot("TELEGRAM_BOT_HIDDEN_TOKEN")
+	botHidden, err := setupBot("TELEGRAM_BOT_HIDDEN_TOKEN")
 	if err != nil {
 		log.Printf("Bot setup failed: %v. Fallback to main bot.", err)
 		botHidden = bot
 	}
 
-	return bot, botHidden, nil
+	return botHidden
+
+}
+
+func setupBots() (*telegram.BotAPI, *telegram.BotAPI, error) {
+	log.Println("Setup the main bot")
+	bot, err := setupBot("TELEGRAM_BOT_TOKEN")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return bot, setupHiddenBot(bot), nil
 }
 
 func leaveChat(bot TrollShieldBot, update *telegram.Update, trollGroup string) {

--- a/troll_shield_test.go
+++ b/troll_shield_test.go
@@ -174,8 +174,13 @@ func TestSetupBot(t *testing.T) {
 }
 
 func TestSetupBots(t *testing.T) {
-	if _, _, err := setupBots(); err == nil {
+	bot, _, err := setupBots()
+	if err == nil {
 		t.Errorf("setupBots fail with invalid tokens.")
+	}
+	botHidden := setupHiddenBot(bot)
+	if botHidden != bot {
+		t.Errorf("When botHidden fails to start, use bot as fallback")
 	}
 }
 


### PR DESCRIPTION
# Changelog
## Add secondary bot setup to only make findTrollHouses request 
This is important because if the target trollHouse banned this bot, it
will fail to find troll with this error:

    {
        "description": "Forbidden: bot was kicked from the supergroup chat",
        "error_code": 403,
        "ok": false
    }

However, if we use a hidden bot (unknown from trolls) to only make
this request, it works pretty fine. After all, they never will know
which bot to ban to stop the troll-shield.

This feature is optional and it's enabled automatically when the env var `TELEGRAM_BOT_HIDDEN_TOKEN` is available.

##  Add leaveChat events when troll-shield is on trollGroups

Now the bot will leaves the chat when happens this events:
- The bot was added to a trollGroup
- A previous trollGroup interacted with the bot