### PR TITLE
Disable welcomeMessage for non-banned join

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,8 +59,6 @@ func main() {
 							log.Printf("saving kills failed: %v", err)
 						}
 					}
-				} else if fromChatEvent(&update, "commonlispbr") && !member.IsBot {
-					welcomeMessage(bot, &update, member)
 				}
 
 				// Exit automatically from groups when I'm joining it


### PR DESCRIPTION
Now only when pass system is used the welcomeMessage is triggered. When the pass system is used it's important to ensure the read of rules, I think.

The behavior to print the welcomeMessage after each non-banned user can be annoying because a lot of them are bots. join_captcha_bot will erase that messages, but the welcomeMessages from our bot will remains.

That creates a lot of noises on the group.