### PR TITLE
Enable static go binary at deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 server=lisp@bikelis
-go build
+CGO_ENABLED=0 go build  -a -ldflags '-extldflags "-static"' .
 ssh $server 'pkill troll-shield || true'
 scp troll-shield $server:
 git describe --tags | ssh $server 'cat > version.txt'


### PR DESCRIPTION
By building static binaries it simplifies some problems with divergent glibc version between my machine
and the server which hosts the troll-shield bot.

I thought that was the default behavior of go compiler... but I think they changed for some reason.